### PR TITLE
fix: add jestOpenAPI function export to type declaration file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,3 +3,4 @@ Authors ordered by first contribution:
  - Richard Waller (https://github.com/rwalle61)
  - Jonny Spruce (https://github.com/JonnySpruce)
  - Alex Dobeck (https://github.com/AlexDobeck)
+ - Ben Guthrie (https://github.com/BenGu3)

--- a/packages/jest-openapi/index.d.ts
+++ b/packages/jest-openapi/index.d.ts
@@ -21,3 +21,6 @@ declare global {
     }
   }
 }
+
+declare function jestOpenAPI(filepathOrObject: string|object): void;
+export = jestOpenAPI;


### PR DESCRIPTION
The default function was missing in the Typescript declarations for jest-openapi (similar to #61 which is fixed by these [two lines](https://github.com/RuntimeTools/OpenAPIValidators/blob/master/packages/chai-openapi-response-validator/index.d.ts#L25)).
This fixes #73.