### PR TITLE
release 0.9.2

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-openapi",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Jest matchers for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**jest-openapi**

fix:
* correct jest-openapi type declaration file https://github.com/RuntimeTools/OpenAPIValidators/pull/74
* make jest-openapi easier to use in test runners other than Jest #76