### PR TITLE
fix: pull jest expect off global when function is called

### DIFF
--- a/packages/jest-openapi/src/index.js
+++ b/packages/jest-openapi/src/index.js
@@ -2,9 +2,9 @@ const { openApiSpecFactory } = require('./openapi-validator');
 const toSatisfyApiSpec = require('./matchers/toSatisfyApiSpec');
 const toSatisfySchemaInApiSpec = require('./matchers/toSatisfySchemaInApiSpec');
 
-const jestExpect = global.expect;
-
 module.exports = function (filepathOrObject) {
+  const jestExpect = global.expect;
+
   const openApiSpec = openApiSpecFactory.makeApiSpec(filepathOrObject);
 
   const jestMatchers = {


### PR DESCRIPTION
**Describe the bug**
When using another test runner (such as mocha) with Jest expect, you have to manually set Jest as the global expect. This means that global expect has to be set when this library is imported, rather than when the library is used.

```
const jestExpect = require('expect')
global.expect = jestExpect
```

**To Reproduce**
https://github.com/BenGu3/jest-openapi-validator-bug

**Expected behavior**
The library verifies that `global.expect` exists when the init function is called, not when the library is imported.