### PR TITLE
chore(deps): updated openapi-response-validator to ^4.0.0 (was ^3.8.2)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,3 +4,4 @@ Authors ordered by first contribution:
  - Jonny Spruce (https://github.com/JonnySpruce)
  - Alex Dobeck (https://github.com/AlexDobeck)
  - Ben Guthrie (https://github.com/BenGu3)
+ - Martijn Vegter (https://github.com/mvegter)

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/package.json
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/package.json
@@ -9,7 +9,7 @@
     "compress-tag": "^2.0.0",
     "fs-extra": "^9.0.0",
     "js-yaml": "^3.13.1",
-    "openapi-response-validator": "^3.8.2",
+    "openapi-response-validator": "^4.0.0",
     "openapi-schema-validator": "^3.0.3",
     "path-parser": "^6.1.0",
     "typeof": "^1.0.0"


### PR DESCRIPTION
Hi, thanks for the great package. Could the `openapi-response-validator` dependency be updated to the next major release range?