### PR TITLE
test: fix RequestPromise test

### DIFF
--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/differentRequestModules.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/differentRequestModules.test.js
@@ -363,7 +363,11 @@ describe('Parsing responses from different request modules', function () {
     describe('res header is application/json, and res.body is a string', function () {
       let res;
       before(async function () {
-        res = await supertest(app).get('/test/header/application/json/and/responseBody/string');
+        res = await requestPromise({
+          method: 'GET',
+          uri: `${appOrigin}/test/header/application/json/and/responseBody/string`,
+          resolveWithFullResponse: true,
+        });
       });
       it('passes', function () {
         expect(res).to.satisfyApiSpec;


### PR DESCRIPTION
We were accidentally testing `supertest` when we should have been testing `request-promise`! This improves coverage and explains why `RequestPromiseReponse.js` uses `replace` on the `res.body`, which is relevant to https://github.com/RuntimeTools/OpenAPIValidators/pull/81#issuecomment-636326923