### PR TITLE
test: renable mutation tests

### DIFF
--- a/commonTestResources/exampleOpenApiFiles/valid/openapi2.json
+++ b/commonTestResources/exampleOpenApiFiles/valid/openapi2.json
@@ -190,6 +190,46 @@
         }
       }
     },
+    "/test/responseBody/object/depthOver2": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Response body should be nested object",
+            "schema": {
+              "type": "object",
+              "required": [
+                "a"
+              ],
+              "properties": {
+                "a": {
+                  "type": "object",
+                  "required": [
+                    "b"
+                  ],
+                  "properties": {
+                    "b": {
+                      "type": "object",
+                      "required": [
+                        "c"
+                      ],
+                      "properties": {
+                        "c": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/test/responseBody/object/withMultipleProperties": {
       "get": {
         "produces": [

--- a/commonTestResources/exampleOpenApiFiles/valid/openapi3.yml
+++ b/commonTestResources/exampleOpenApiFiles/valid/openapi3.yml
@@ -22,6 +22,30 @@ paths:
             application/json:
               schema:
                 type: boolean
+  /test/responseBody/object/depthOver2:
+    get:
+      responses:
+        200:
+          description: Response body should be a nested object
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - a
+                properties:
+                  a:
+                    type: object
+                    required:
+                      - b
+                    properties:
+                      b:
+                        type: object
+                        required:
+                          - c
+                        properties:
+                          c:
+                            type: string
   /test/responseBody/object/withMultipleProperties:
     get:
       responses:

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AbstractResponse.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AbstractResponse.js
@@ -5,12 +5,6 @@ class AbstractResponse {
     this.res = res;
   }
 
-  hasNoBody() {
-    const hasNoContentTypeHeader = Object.prototype.hasOwnProperty.call(this.res, 'headers')
-      && !Object.prototype.hasOwnProperty.call(this.res.headers, 'content-type');
-    return (hasNoContentTypeHeader && this.bodyHasNoContent);
-  }
-
   summary() {
     return {
       body: this.body,

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AxiosResponse.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AxiosResponse.js
@@ -10,7 +10,7 @@ class AxiosResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     return this.body;

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/RequestPromiseResponse.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/RequestPromiseResponse.js
@@ -10,7 +10,7 @@ class RequestPromiseResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     try {

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/SuperAgentResponse.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/SuperAgentResponse.js
@@ -13,7 +13,7 @@ class SuperAgentResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     if (this.isResTextPopulatedInsteadOfResBody) {

--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -10,7 +10,7 @@
     "test:coverage:browse": "npm run test:coverage; open coverage/lcov-report/index.html",
     "test:mutation": "stryker run",
     "posttest:mutation": "rimraf commonTestResources",
-    "test:precommit": "npm run lint && npm run test:coverage",
+    "test:precommit": "npm run lint && npm run test:coverage && npm run test:mutation",
     "test:ci": "npm run test:precommit",
     "lint": "eslint {lib,test}/**/*.js",
     "lint:fix": "npm run lint -- --fix"

--- a/packages/chai-openapi-response-validator/stryker.conf.js
+++ b/packages/chai-openapi-response-validator/stryker.conf.js
@@ -33,7 +33,7 @@ module.exports = function (config) {
     transpilers: [],
     testFramework: 'mocha',
     coverageAnalysis: 'perTest',
-    thresholds: { high: 100, low: 99, break: 96 },
+    thresholds: { high: 100, low: 99, break: 98 },
     packageManager: 'yarn',
   });
 };

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/satisfyApiSpec.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/satisfyApiSpec.test.js
@@ -186,6 +186,35 @@ openApiSpecs.forEach((spec) => {
               );
             });
           });
+
+          describe('be a object with depth of over 2', function () {
+            const nestedObject = {
+              a: {
+                b: {
+                  c: 'valid string',
+                },
+              },
+            };
+            const res = {
+              status: 200,
+              req: {
+                method: 'GET',
+                path: '/test/responseBody/object/depthOver2',
+              },
+              body: nestedObject,
+            };
+
+            it('passes', function () {
+              expect(res).to.satisfyApiSpec;
+            });
+
+            it('fails when using .not', function () {
+              const assertion = () => expect(res).to.not.satisfyApiSpec;
+              expect(assertion).to.throw(
+                `res contained: ${str({ body: nestedObject })}`,
+              );
+            });
+          });
         });
 
         describe('res.req.path matches a response referencing a response definition', function () {

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.js
@@ -175,6 +175,35 @@ openApiSpecs.forEach((spec) => {
               );
             });
           });
+
+          describe('be a object with depth of over 2', () => {
+            const nestedObject = {
+              a: {
+                b: {
+                  c: 'valid string',
+                },
+              },
+            };
+            const res = {
+              status: 200,
+              req: {
+                method: 'GET',
+                path: '/test/responseBody/object/depthOver2',
+              },
+              body: nestedObject,
+            };
+
+            it('passes', () => {
+              expect(res).toSatisfyApiSpec();
+            });
+
+            it('fails when using .not', () => {
+              const assertion = () => expect(res).not.toSatisfyApiSpec();
+              expect(assertion).toThrow(
+                `${red('received')} contained: ${red(str({ body: nestedObject }))}`,
+              );
+            });
+          });
         });
 
         describe('res.req.path matches a response referencing a response definition', () => {

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/AbstractResponse.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/AbstractResponse.js
@@ -5,12 +5,6 @@ class AbstractResponse {
     this.res = res;
   }
 
-  hasNoBody() {
-    const hasNoContentTypeHeader = Object.prototype.hasOwnProperty.call(this.res, 'headers')
-      && !Object.prototype.hasOwnProperty.call(this.res.headers, 'content-type');
-    return (hasNoContentTypeHeader && this.bodyHasNoContent);
-  }
-
   summary() {
     return {
       body: this.body,

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/AxiosResponse.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/AxiosResponse.js
@@ -10,7 +10,7 @@ class AxiosResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     return this.body;

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/RequestPromiseResponse.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/RequestPromiseResponse.js
@@ -10,7 +10,7 @@ class RequestPromiseResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     try {

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/SuperAgentResponse.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/SuperAgentResponse.js
@@ -13,7 +13,7 @@ class SuperAgentResponse extends AbstractResponse {
   }
 
   getBodyForValidation() {
-    if (this.hasNoBody()) {
+    if (this.bodyHasNoContent) {
       return null;
     }
     if (this.isResTextPopulatedInsteadOfResBody) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2832,11 +2832,6 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-promise@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.0.tgz#3ebfc546cee7064c314686279cc9df7bc2724715"
-  integrity sha512-N/4ZxZGjDLAWJQNtcq1/5AOiWTAAhDwnjlaGPaC2+p3pQ+Ka2Dl/EL29DppuoiZ8Xr1/p/9ywBGGzHRPoWKfGA==
-
 is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
@@ -4674,11 +4669,9 @@ rsvp@^4.8.4:
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
-  integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
-  dependencies:
-    is-promise "^2.1.0"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 rxjs@^6.5.3, rxjs@~6.5.1:
   version "6.5.5"


### PR DESCRIPTION
This renables mutation tests in the PR build, and restores the mutation score of `chai-openapi-response-validator` to nearly 100%. 

The mutation tests were skipped while `stryker`'s subdependency `run-async`'s subdependency `is-promise` was broken. I've updated our version of `run-async`, which no longer uses `is-promise`

There are 4 mutants remaining. I'm happy to leave the first 3 because they are about error cases that I don't know how to test usefully. The 4th should be killed when we complete https://github.com/RuntimeTools/OpenAPIValidators/issues/57

```
153. [Survived] StringLiteral
/Users/richard.waller@ibm.com/Documents/Projects/SideProjects/OpenApiChai/OpenAPIValidators/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AbstractOpenApiSpec.js:138:8
-           'INVALID_OBJECT',
+           "",

178. [Survived] StringLiteral
/Users/richard.waller@ibm.com/Documents/Projects/SideProjects/OpenApiChai/OpenAPIValidators/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AbstractOpenApiSpec.js:107:8
-           'INVALID_BODY',
+           "",

180. [Survived] ConditionalExpression
/Users/richard.waller@ibm.com/Documents/Projects/SideProjects/OpenApiChai/OpenAPIValidators/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/AbstractOpenApiSpec.js:90:10
-         if (error instanceof ValidationError) {
+         if (true) {

308. [Survived] ConditionalExpression
/Users/richard.waller@ibm.com/Documents/Projects/SideProjects/OpenApiChai/OpenAPIValidators/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/OpenApi3Spec.js:73:8
-       if (!matchingServerBasePaths.length) {
+       if (false) {
```