### PR TITLE
release 0.9.3

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-openapi",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Jest matchers for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**chai-openapi-response-validator** and **jest-openapi**

fix:
* support request-promise returning parsed json https://github.com/RuntimeTools/OpenAPIValidators/pull/74 @ludeknovy 

chore(deps):
* updated openapi-response-validator to ^4.0.0 (was ^3.8.2) https://github.com/RuntimeTools/OpenAPIValidators/pull/79 @mvegter 