### PR TITLE
chore(deps-dev): bump mocha from 7.1.1 to 7.2.0

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -54,7 +54,7 @@
     "eslint-plugin-mocha": "^7.0.1",
     "express": "^4.17.1",
     "fs-extra": "^9.0.1",
-    "mocha": "^7.1.1",
+    "mocha": "^7.2.0",
     "nyc": "15.1.0",
     "request": "^2.88.2",
     "request-promise": "^4.2.5",

--- a/packages/chai-openapi-response-validator/stryker.conf.js
+++ b/packages/chai-openapi-response-validator/stryker.conf.js
@@ -35,5 +35,6 @@ module.exports = function (config) {
     coverageAnalysis: 'perTest',
     thresholds: { high: 100, low: 99, break: 98 },
     packageManager: 'yarn',
+    maxConcurrentTestRunners: 1,
   });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3767,14 +3767,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.3.tgz#5a514b7179259287952881e94410ec5465659f8c"
-  integrity sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==
-  dependencies:
-    minimist "^1.2.5"
-
-mkdirp@^0.5.1:
+mkdirp@0.5.5, mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -3786,10 +3779,10 @@ mkdirp@~1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mocha@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.1.1.tgz#89fbb30d09429845b1bb893a830bf5771049a441"
-  integrity sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==
+mocha@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-7.2.0.tgz#01cc227b00d875ab1eed03a75106689cfed5a604"
+  integrity sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==
   dependencies:
     ansi-colors "3.2.3"
     browser-stdout "1.3.1"
@@ -3804,7 +3797,7 @@ mocha@^7.1.1:
     js-yaml "3.13.1"
     log-symbols "3.0.0"
     minimatch "3.0.4"
-    mkdirp "0.5.3"
+    mkdirp "0.5.5"
     ms "2.1.1"
     node-environment-flags "1.0.6"
     object.assign "4.1.0"


### PR DESCRIPTION
Reverts https://github.com/RuntimeTools/OpenAPIValidators/pull/105, which reverted https://github.com/RuntimeTools/OpenAPIValidators/pull/94

I realised mocha 7.2.0 made our stryker mutation tests throw those annoying port `listen EADDRINUSE` errors only because (I think) mocha 7.2.0 enables stryker to run mocha tests concurrently. By forcing the `maxConcurrentTestRunners` to be 1, the tests using ports should not conflict with each other