### PR TITLE
release 0.9.4

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-openapi",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Jest matchers for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**chai-openapi-response-validator** and **jest-openapi**

fix:
* request paths should match non-templated OpenAPI paths over templated OpenAPI paths https://github.com/RuntimeTools/OpenAPIValidators/pull/107 @rwalle61 