### PR TITLE
feat, test, refactor(jest): port openapi2 basepath support etc.

### DIFF
--- a/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.js
+++ b/packages/chai-openapi-response-validator/lib/assertions/satisfyApiSpec.js
@@ -36,7 +36,6 @@ function getExpectedResToSatisfyApiSpecMsg(
 
   const { status, req } = actualResponse;
   const { method, path: requestPath } = req;
-
   const unmatchedEndpoint = `${method} ${requestPath}`;
 
   if (validationError.code === `SERVER_NOT_FOUND`) {

--- a/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/OpenApi2Spec.js
+++ b/packages/chai-openapi-response-validator/lib/openapi-validator/lib/classes/OpenApi2Spec.js
@@ -12,7 +12,7 @@ class OpenApi2Spec extends AbstractOpenApiSpec {
   }
 
   /**
-   * "If the basePath property is not provided, is not included, the API is served directly under the host
+   * "If the basePath property is not provided, the API is served directly under the host
    * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields
    */
   findOpenApiPathMatchingPathname(pathname) {

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/differentRequestModules.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/differentRequestModules.test.js
@@ -17,18 +17,18 @@
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const path = require('path');
-const { inspect } = require('util');
 
 const chaiHttp = require('chai-http');
 const axios = require('axios');
 const supertest = require('supertest');
 const requestPromise = require('request-promise');
 
-const chaiResponseValidator = require('../../..');
+const { str } = require('../../../../../commonTestResources/utils');
 const app = require('../../../../../commonTestResources/exampleApp');
 const { port } = require('../../../../../commonTestResources/config');
 
-const str = (obj) => inspect(obj, { showHidden: false, depth: null });
+const chaiResponseValidator = require('../../..');
+
 const appOrigin = `http://localhost:${port}`;
 const pathToApiSpec = path.resolve(
   '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.yml',

--- a/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/specsDefineServersDifferently.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfyApiSpec/specsDefineServersDifferently.test.js
@@ -23,6 +23,8 @@ const {
 } = require('../../../../../commonTestResources/utils');
 const chaiResponseValidator = require('../../..');
 
+const expectedResToSatisfyApiSpec = 'expected res to satisfy API spec';
+
 const dirContainingApiSpec = path.resolve(
   '../../commonTestResources/exampleOpenApiFiles/valid/serversDefinedDifferently',
 );
@@ -131,7 +133,6 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
             "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec",
             "res had request path '/nonExistentEndpointPath', but your API spec has no matching path",
             'Paths found in API spec:',
-            // we don't list servers defined in your API spec because there aren't any
           ),
         );
       });
@@ -151,7 +152,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       chai.use(chaiResponseValidator(pathToApiSpec));
     });
 
-    describe('res.req.path does not match any servers', () => {
+    describe('res.req.path matches no servers', () => {
       const res = {
         status: 200,
         req: {
@@ -165,10 +166,10 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).to.satisfyApiSpec;
         expect(assertion).to.throw(
           joinWithNewLines(
-            'expected res to satisfy API spec',
+            expectedResToSatisfyApiSpec,
             "expected res to satisfy a '200' response defined for endpoint 'GET /nonExistentServer' in your API spec",
             "res had request path '/nonExistentServer', but your API spec has no matching servers",
-            'Servers found in API spec: /relativeServer, /differentRelativeServer', // etc.
+            'Servers found in API spec: /relativeServer, /differentRelativeServer, /relativeServer2, http://api.example.com/basePath1, https://api.example.com/basePath2, ws://api.example.com/basePath3, wss://api.example.com/basePath4, http://api.example.com:8443/basePath5, http://localhost:3025/basePath6, http://10.0.81.36/basePath7',
           ),
         );
       });
@@ -331,30 +332,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       });
     });
 
-    describe("res.req.path does not match any defined servers, nor the default server ('/')", () => {
-      const res = {
-        status: 200,
-        req: {
-          method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
-        },
-        body: 'valid body (string)',
-      };
-
-      it('fails', () => {
-        const assertion = () => expect(res).to.satisfyApiSpec;
-        expect(assertion).to.throw(
-          AssertionError,
-          "'nonExistentServer/test/responseBody/string', but your API spec has no matching servers",
-        );
-      });
-
-      it('passes when using .not', () => {
-        expect(res).to.not.satisfyApiSpec;
-      });
-    });
-
-    describe("res.req.path does not match any defined servers, but does match the default server ('/')", () => {
+    describe('res.req.path matches no servers', () => {
       const res = {
         status: 200,
         req: {

--- a/packages/chai-openapi-response-validator/test/assertions/satisfySchemaInApiSpec/satisfySchemaInApiSpec.test.js
+++ b/packages/chai-openapi-response-validator/test/assertions/satisfySchemaInApiSpec/satisfySchemaInApiSpec.test.js
@@ -98,7 +98,6 @@ openApiSpecs.forEach((spec) => {
               expect(validObj).to.not.satisfySchemaInApiSpec(schemaName);
             expect(assertion).to.throw(
               joinWithNewLines(
-                `expected object not to satisfy the '${schemaName}' schema defined in your API spec`,
                 'object was: 123',
                 `The '${schemaName}' schema in API spec: ${str(
                   expectedSchema,
@@ -116,7 +115,6 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).to.satisfySchemaInApiSpec(schemaName);
             expect(assertion).to.throw(
               joinWithNewLines(
-                `expected object to satisfy the '${schemaName}' schema defined in your API spec`,
                 'object did not satisfy it because: object should be integer',
                 "object was: 'should be integer'",
                 `The '${schemaName}' schema in API spec: ${str(

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/differentRequestModules.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/differentRequestModules.test.js
@@ -1,15 +1,15 @@
 const path = require('path');
-const { inspect } = require('util');
 
 const axios = require('axios');
 const supertest = require('supertest');
 const requestPromise = require('request-promise');
 
-const jestOpenAPI = require('../../..');
+const { str } = require('../../../../../commonTestResources/utils');
 const app = require('../../../../../commonTestResources/exampleApp');
 const { port } = require('../../../../../commonTestResources/config');
 
-const str = (obj) => inspect(obj, { showHidden: false, depth: null });
+const jestOpenAPI = require('../../..');
+
 const appOrigin = `http://localhost:${port}`;
 const pathToApiSpec = path.resolve(
   '../../commonTestResources/exampleOpenApiFiles/valid/openapi3.yml',

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/specsDefineBasePathDifferently.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/specsDefineBasePathDifferently.test.js
@@ -1,0 +1,156 @@
+const path = require('path');
+const jestMatcherUtils = require('jest-matcher-utils');
+
+const {
+  joinWithNewLines,
+} = require('../../../../../commonTestResources/utils');
+const jestOpenAPI = require('../../..');
+
+const red = jestMatcherUtils.RECEIVED_COLOR;
+const green = jestMatcherUtils.EXPECTED_COLOR;
+
+const dirContainingApiSpec = path.resolve(
+  '../../commonTestResources/exampleOpenApiFiles/valid/basePathDefinedDifferently',
+);
+describe('Using OpenAPI 2 specs that define basePath differently', () => {
+  describe('spec has no basePath property', () => {
+    beforeAll(() => {
+      const pathToApiSpec = path.join(
+        dirContainingApiSpec,
+        'noBasePathProperty.yml',
+      );
+      jestOpenAPI(pathToApiSpec);
+    });
+
+    describe('res.req.path matches an endpoint path', () => {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', () => {
+        expect(res).toSatisfyApiSpec();
+      });
+
+      it('fails when using .not', () => {
+        const assertion = () => expect(res).not.toSatisfyApiSpec();
+        expect(assertion).toThrow(Error, '');
+      });
+    });
+
+    describe('res.req.path matches no endpoint paths', () => {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', () => {
+        const assertion = () => expect(res).toSatisfyApiSpec();
+        expect(assertion).toThrow(
+          // prettier-ignore
+          `${joinWithNewLines(
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /test/nonExistentEndpointPath' in your API spec`,
+            `${red('received')} had request path ${red('/test/nonExistentEndpointPath')}, but your API spec has no matching path`,
+            `Paths found in API spec: ${green('/test/responseBody/string')}`,
+          )}`,
+        );
+      });
+
+      it('passes when using .not', () => {
+        expect(res).not.toSatisfyApiSpec();
+      });
+    });
+  });
+
+  describe('spec has basePath property', () => {
+    beforeAll(() => {
+      const pathToApiSpec = path.join(
+        dirContainingApiSpec,
+        'basePathProperty.yml',
+      );
+      jestOpenAPI(pathToApiSpec);
+    });
+
+    describe('res.req.path matches the basePath and an endpoint path', () => {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('passes', () => {
+        expect(res).toSatisfyApiSpec();
+      });
+
+      it('fails when using .not', () => {
+        const assertion = () => expect(res).not.toSatisfyApiSpec();
+        expect(assertion).toThrow(Error, '');
+      });
+    });
+
+    describe('res.req.path does not match the basePath', () => {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/responseBody/string',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', () => {
+        const assertion = () => expect(res).toSatisfyApiSpec();
+        expect(assertion).toThrow(
+          // prettier-ignore
+          joinWithNewLines(
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /responseBody/string' in your API spec`,
+            `${red('received')} had request path ${red('/responseBody/string')}, but your API spec has basePath ${green('/test')}`,
+          ),
+        );
+      });
+
+      it('passes when using .not', () => {
+        expect(res).not.toSatisfyApiSpec();
+      });
+    });
+
+    describe('res.req.path matches the basePath but no endpoint paths', () => {
+      const res = {
+        status: 200,
+        req: {
+          method: 'GET',
+          path: '/test/nonExistentEndpointPath',
+        },
+        body: 'valid body (string)',
+      };
+
+      it('fails', () => {
+        const assertion = () => expect(res).toSatisfyApiSpec();
+        expect(assertion).toThrow(
+          // prettier-ignore
+          joinWithNewLines(
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /test/nonExistentEndpointPath' in your API spec`,
+            `${red('received')} had request path ${red('/test/nonExistentEndpointPath')}, but your API spec has no matching path`,
+            `Paths found in API spec: ${green('/responseBody/string')}`,
+            "'/test/nonExistentEndpointPath' matches basePath `/test` but no <basePath/endpointPath> combinations",
+          ),
+        );
+      });
+
+      it('passes when using .not', () => {
+        expect(res).not.toSatisfyApiSpec();
+      });
+    });
+  });
+});

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/specsDefineServersDifferently.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/specsDefineServersDifferently.test.js
@@ -1,7 +1,10 @@
 const path = require('path');
-const { inspect } = require('util');
 const jestMatcherUtils = require('jest-matcher-utils');
 
+const {
+  joinWithNewLines,
+  str,
+} = require('../../../../../commonTestResources/utils');
 const jestOpenAPI = require('../../..');
 
 const expectReceivedToSatisfyApiSpec = jestMatcherUtils.matcherHint(
@@ -32,7 +35,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       jestOpenAPI(pathToApiSpec);
     });
 
-    describe("res.req.path matches the default server ('/') and an endpoint path", () => {
+    describe('res.req.path matches an endpoint path', () => {
       const res = {
         status: 200,
         req: {
@@ -51,32 +54,8 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         expect(assertion).toThrow(Error, '');
       });
     });
-    describe('res.req.path does not match any servers', () => {
-      const res = {
-        status: 200,
-        req: {
-          method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
-        },
-        body: 'valid body (string)',
-      };
 
-      it('fails', () => {
-        const assertion = () => expect(res).toSatisfyApiSpec();
-        expect(assertion).toThrow(
-          // prettier-ignore
-          `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET nonExistentServer/test/responseBody/string' in your API spec`
-          + `\n${red('received')} had request path ${red('nonExistentServer/test/responseBody/string')}, but your API spec has no matching path`
-          + '\n\nPaths found in API spec:',
-          // we don't list servers defined in your API spec because there aren't any
-        );
-      });
-
-      it('passes when using .not', () => {
-        expect(res).not.toSatisfyApiSpec();
-      });
-    });
-    describe("res.req.path matches the default server ('/') but no endpoint paths", () => {
+    describe('res.req.path matches no endpoint paths', () => {
       const res = {
         status: 200,
         req: {
@@ -90,10 +69,11 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
           // prettier-ignore
-          `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`
-          + `\n${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`
-          + '\n\nPaths found in API spec:',
-          // we don't list servers defined in your API spec because there aren't any
+          joinWithNewLines(
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
+            `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
+            'Paths found in API spec:',
+          ),
         );
       });
 
@@ -112,7 +92,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       jestOpenAPI(pathToApiSpec);
     });
 
-    describe("res.req.path matches the default server ('/') and an endpoint path", () => {
+    describe('res.req.path matches an endpoint path', () => {
       const res = {
         status: 200,
         req: {
@@ -131,32 +111,8 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         expect(assertion).toThrow(Error, '');
       });
     });
-    describe('res.req.path does not match any servers', () => {
-      const res = {
-        status: 200,
-        req: {
-          method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
-        },
-        body: 'valid body (string)',
-      };
 
-      it('fails', () => {
-        const assertion = () => expect(res).toSatisfyApiSpec();
-        expect(assertion).toThrow(
-          // prettier-ignore
-          `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET nonExistentServer/test/responseBody/string' in your API spec`
-          + `\n${red('received')} had request path ${red('nonExistentServer/test/responseBody/string')}, but your API spec has no matching path`
-          + '\n\nPaths found in API spec:',
-          // we don't list servers defined in your API spec because there aren't any
-        );
-      });
-
-      it('passes when using .not', () => {
-        expect(res).not.toSatisfyApiSpec();
-      });
-    });
-    describe("res.req.path matches the default server ('/') but no endpoint paths", () => {
+    describe('res.req.path matches no endpoint paths', () => {
       const res = {
         status: 200,
         req: {
@@ -170,10 +126,11 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
           // prettier-ignore
-          `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`
-          + `\n${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`
-          + '\n\nPaths found in API spec:',
-          // we don't list servers defined in your API spec because there aren't any
+          joinWithNewLines(
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentEndpointPath' in your API spec`,
+            `${red('received')} had request path ${red('/nonExistentEndpointPath')}, but your API spec has no matching path`,
+            'Paths found in API spec:',
+          ),
         );
       });
 
@@ -192,12 +149,12 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       jestOpenAPI(pathToApiSpec);
     });
 
-    describe('res.req.path does not match any servers', () => {
+    describe('res.req.path matches no servers', () => {
       const res = {
         status: 200,
         req: {
           method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
+          path: '/nonExistentServer',
         },
         body: 'valid body (string)',
       };
@@ -206,12 +163,12 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
           // prettier-ignore
-          `${expectReceivedToSatisfyApiSpec}`
-          + `\n\nexpected ${red('received')} to satisfy a '200' response defined for endpoint 'GET nonExistentServer/test/responseBody/string' in your API spec`
-          + `\n${red('received')} had request path ${red('nonExistentServer/test/responseBody/string')}, but your API spec has no matching path`
-          + `\n\nPaths found in API spec: ${green('/test/responseBody/string')}`
-          + '\n\n\'nonExistentServer/test/responseBody/string\' matches no servers'
-          + '\n\nServers found in API spec: /relativeServer, /differentRelativeServer', // etc.
+          joinWithNewLines(
+            `${expectReceivedToSatisfyApiSpec}`,
+            `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET /nonExistentServer' in your API spec`,
+            `${red('received')} had request path ${red('/nonExistentServer')}, but your API spec has no matching servers`,
+            `Servers found in API spec: ${green('/relativeServer, /differentRelativeServer, /relativeServer2, http://api.example.com/basePath1, https://api.example.com/basePath2, ws://api.example.com/basePath3, wss://api.example.com/basePath4, http://api.example.com:8443/basePath5, http://localhost:3025/basePath6, http://10.0.81.36/basePath7')}`,
+          ),
         );
       });
 
@@ -286,6 +243,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
             expect(assertion).toThrow(Error, '');
           });
         });
+
         describe('res.req.path matches a server but no endpoint paths', () => {
           const res = {
             status: 200,
@@ -300,11 +258,14 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
             const assertion = () => expect(res).toSatisfyApiSpec();
             expect(assertion).toThrow(
               // prettier-ignore
-              `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET ${serverBasePath}/nonExistentEndpointPath' in your API spec`
-              + `\n${red('received')} had request path ${red(`${serverBasePath}/nonExistentEndpointPath`)}, but your API spec has no matching path`
-              + `\n\nPaths found in API spec: ${green('/test/responseBody/string')}`
-              + `\n\n'${serverBasePath}/nonExistentEndpointPath' matches servers ${inspect(expectedMatchingServers)} but no <server/endpointPath> combinations`
-              + '\n\nServers found in API spec: /relativeServer, /differentRelativeServer', // etc.
+              joinWithNewLines(
+                `expected ${red('received')} to satisfy a '200' response defined for endpoint 'GET ${serverBasePath}/nonExistentEndpointPath' in your API spec`,
+                `${red('received')} had request path ${red(`${serverBasePath}/nonExistentEndpointPath`)}, but your API spec has no matching path`,
+                `Paths found in API spec: ${green('/test/responseBody/string')}`,
+                `'${serverBasePath}/nonExistentEndpointPath' matches servers ${str(
+                  expectedMatchingServers,
+                )} but no <server/endpointPath> combinations`,
+              ),
             );
           });
 
@@ -325,7 +286,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       jestOpenAPI(pathToApiSpec);
     });
 
-    describe('res.req.matches a server base path and an endpoint path', () => {
+    describe('res.req.matches a server and an endpoint path', () => {
       const res = {
         status: 200,
         req: {
@@ -345,7 +306,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       });
     });
 
-    describe('res.req.path matches a server base path but no endpoint paths', () => {
+    describe('res.req.path matches a server but no endpoint paths', () => {
       const res = {
         status: 200,
         req: {
@@ -358,7 +319,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       it('fails', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
-          `'/basePath1/nonExistentEndpointPath' matches servers ${inspect([
+          `'/basePath1/nonExistentEndpointPath' matches servers ${str([
             'http://api.example.com/basePath1',
           ])} but no <server/endpointPath> combinations`,
         );
@@ -369,29 +330,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       });
     });
 
-    describe("res.req.path does not match any defined server base paths, nor the default base path ('/')", () => {
-      const res = {
-        status: 200,
-        req: {
-          method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
-        },
-        body: 'valid body (string)',
-      };
-
-      it('fails', () => {
-        const assertion = () => expect(res).toSatisfyApiSpec();
-        expect(assertion).toThrow(
-          "'nonExistentServer/test/responseBody/string' matches no servers",
-        );
-      });
-
-      it('passes when using .not', () => {
-        expect(res).not.toSatisfyApiSpec();
-      });
-    });
-
-    describe("res.req.path does not match any defined server base paths, but does match the default base path ('/')", () => {
+    describe('res.req.path matches no servers', () => {
       const res = {
         status: 200,
         req: {
@@ -404,7 +343,8 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       it('fails', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
-          "'/test/responseBody/string' matches no servers",
+          // prettier-ignore
+          `${red('/test/responseBody/string')}, but your API spec has no matching servers`,
         );
       });
 
@@ -423,7 +363,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       jestOpenAPI(pathToApiSpec);
     });
 
-    describe("res.req.path matches the default server base path ('/') and an endpoint path", () => {
+    describe('res.req.path matches an endpoint path', () => {
       const res = {
         status: 200,
         req: {
@@ -443,7 +383,7 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       });
     });
 
-    describe("res.req.path matches the default server base path ('/') but no endpoint paths", () => {
+    describe('res.req.path matches no endpoint paths', () => {
       const res = {
         status: 200,
         req: {
@@ -456,31 +396,9 @@ describe('Using OpenAPI 3 specs that define servers differently', () => {
       it('fails', () => {
         const assertion = () => expect(res).toSatisfyApiSpec();
         expect(assertion).toThrow(
-          `'/nonExistentEndpointPath' matches servers ${inspect([
+          `'/nonExistentEndpointPath' matches servers ${str([
             'http://api.example.com',
           ])} but no <server/endpointPath> combinations`,
-        );
-      });
-
-      it('passes when using .not', () => {
-        expect(res).not.toSatisfyApiSpec();
-      });
-    });
-
-    describe("res.req.path does not match the default server base path ('/') nor any servers", () => {
-      const res = {
-        status: 200,
-        req: {
-          method: 'GET',
-          path: 'nonExistentServer/test/responseBody/string',
-        },
-        body: 'valid body (string)',
-      };
-
-      it('fails', () => {
-        const assertion = () => expect(res).toSatisfyApiSpec();
-        expect(assertion).toThrow(
-          "'nonExistentServer/test/responseBody/string' matches no servers",
         );
       });
 

--- a/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfyApiSpec/toSatisfyApiSpec.test.js
@@ -1,8 +1,10 @@
 const path = require('path');
-const util = require('util');
-const { c } = require('compress-tag');
 const jestMatcherUtils = require('jest-matcher-utils');
 
+const {
+  joinWithNewLines,
+  str,
+} = require('../../../../../commonTestResources/utils');
 const jestOpenAPI = require('../../..');
 
 const expectReceivedToSatisfyApiSpec = jestMatcherUtils.matcherHint(
@@ -30,7 +32,6 @@ const expectReceivedNotToSatisfyApiSpec = jestMatcherUtils.matcherHint(
 const red = jestMatcherUtils.RECEIVED_COLOR;
 const green = jestMatcherUtils.EXPECTED_COLOR;
 
-const str = (obj) => util.inspect(obj, { showHidden: false, depth: null });
 const openApiSpecsDir = path.resolve(
   '../../commonTestResources/exampleOpenApiFiles/valid',
 );
@@ -110,11 +111,12 @@ openApiSpecs.forEach((spec) => {
               expect(assertion).toThrow(
                 new Error(
                   // prettier-ignore
-                  c`${expectReceivedNotToSatisfyApiSpec}
-                \n\nexpected ${red('received')} not to satisfy the '200' response defined
-                    for endpoint 'GET /test/responseBody/string' in your API spec
-                \n\n${red('received')} contained: ${red(str({ body: 'valid body (string)' }))}
-                \n\nThe '200' response defined for endpoint 'GET /test/responseBody/string' in API spec: ${green(str(responseDefinition))}`,
+                  joinWithNewLines(
+                    expectReceivedNotToSatisfyApiSpec,
+                    `expected ${red('received')} not to satisfy the '200' response defined for endpoint 'GET /test/responseBody/string' in your API spec`,
+                    `${red('received')} contained: ${red(str({ body: 'valid body (string)' }))}`,
+                    `The '200' response defined for endpoint 'GET /test/responseBody/string' in API spec: ${green(str(responseDefinition))}`,
+                  ),
                 ),
               );
             });
@@ -161,11 +163,12 @@ openApiSpecs.forEach((spec) => {
               expect(assertion).toThrow(
                 new Error(
                   // prettier-ignore
-                  c`${expectReceivedNotToSatisfyApiSpec}
-                \n\nexpected ${red('received')} not to satisfy the '200' response defined
-                    for endpoint 'GET /test/responseBody/referencesSchemaObject/simple' in your API spec
-                \n\n${red('received')} contained: ${red(str({ body: 'valid body (string)' }))}
-                \n\nThe '200' response defined for endpoint 'GET /test/responseBody/referencesSchemaObject/simple' in API spec: ${green(str(responseDefinition))}`,
+                  joinWithNewLines(
+                    expectReceivedNotToSatisfyApiSpec,
+                    `expected ${red('received')} not to satisfy the '200' response defined for endpoint 'GET /test/responseBody/referencesSchemaObject/simple' in your API spec`,
+                    `${red('received')} contained: ${red(str({ body: 'valid body (string)' }))}`,
+                    `The '200' response defined for endpoint 'GET /test/responseBody/referencesSchemaObject/simple' in API spec: ${green(str(responseDefinition))}`,
+                  ),
                 ),
               );
             });
@@ -468,10 +471,12 @@ openApiSpecs.forEach((spec) => {
             const assertion = () => expect(res).toSatisfyApiSpec();
             expect(assertion).toThrow(
               // prettier-ignore
-              c`${expectReceivedToSatisfyApiSpec}
-              \n\nexpected ${red('received')} to satisfy a '418' response defined for endpoint 'GET /test/responseStatus' in your API spec
-              \n${red('received')} had status ${red('418')}, but your API spec has no ${red('418')} response defined for endpoint 'GET /test/responseStatus'
-              \n\nResponse statuses found for endpoint 'GET /test/responseStatus' in API spec: ${green('200, 204')}`,
+              joinWithNewLines(
+                expectReceivedToSatisfyApiSpec,
+                `expected ${red('received')} to satisfy a '418' response defined for endpoint 'GET /test/responseStatus' in your API spec`,
+                `${red('received')} had status ${red('418')}, but your API spec has no ${red('418')} response defined for endpoint 'GET /test/responseStatus'`,
+                `Response statuses found for endpoint 'GET /test/responseStatus' in API spec: ${green('200, 204')}`,
+              ),
             );
           });
 
@@ -531,12 +536,13 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               new Error(
                 // prettier-ignore
-                c`${expectReceivedToSatisfyApiSpec}
-              \n\nexpected ${red('received')} to satisfy the '200' response defined
-                  for endpoint 'GET /test/responseBody/object/withMultipleProperties' in your API spec
-              \n${red('received')} did not satisfy it because: property1 should be string, property2 should be string
-              \n\n${red('received')} contained: ${red(str({ body: { property1: 123, property2: 123 } }))}
-              \n\nThe '200' response defined for endpoint 'GET /test/responseBody/object/withMultipleProperties' in API spec: ${green(str(responseDefinition))}`,
+                joinWithNewLines(
+                  expectReceivedToSatisfyApiSpec,
+                  `expected ${red('received')} to satisfy the '200' response defined for endpoint 'GET /test/responseBody/object/withMultipleProperties' in your API spec`,
+                  `${red('received')} did not satisfy it because: property1 should be string, property2 should be string`,
+                  `${red('received')} contained: ${red(str({ body: { property1: 123, property2: 123 } }))}`,
+                  `The '200' response defined for endpoint 'GET /test/responseBody/object/withMultipleProperties' in API spec: ${green(str(responseDefinition))}`,
+                ),
               ),
             );
           });
@@ -562,9 +568,12 @@ openApiSpecs.forEach((spec) => {
           const assertion = () => expect(res).toSatisfyApiSpec();
           expect(assertion).toThrow(
             // prettier-ignore
-            `expected ${red('received')} to satisfy a '204' response defined for endpoint 'GET /does/not/exist' in your API spec`
-            + `\n${red('received')} had request path ${red('/does/not/exist')}, but your API spec has no matching path`
-            + '\n\nPaths found in API spec:', // etc.
+            joinWithNewLines(
+              expectReceivedToSatisfyApiSpec,
+              `expected ${red('received')} to satisfy a '204' response defined for endpoint 'GET /does/not/exist' in your API spec`,
+              `${red('received')} had request path ${red('/does/not/exist')}, but your API spec has no matching path`,
+              'Paths found in API spec:', // etc.
+            ),
           );
         });
 
@@ -587,10 +596,12 @@ openApiSpecs.forEach((spec) => {
           expect(assertion).toThrow(
             new Error(
               // prettier-ignore
-              c`${expectReceivedToSatisfyApiSpec}
-            \n\nexpected ${red('received')} to satisfy a '204' response defined for endpoint 'HEAD /test/HTTPMethod' in your API spec
-            \n${red('received')} had request method ${red('HEAD')}, but your API spec has no ${red('HEAD')} operation defined for path '/test/HTTPMethod'
-            \n\nRequest operations found for path '/test/HTTPMethod' in API spec: ${green('GET, POST')}`,
+              joinWithNewLines(
+                expectReceivedToSatisfyApiSpec,
+                `expected ${red('received')} to satisfy a '204' response defined for endpoint 'HEAD /test/HTTPMethod' in your API spec`,
+                `${red('received')} had request method ${red('HEAD')}, but your API spec has no ${red('HEAD')} operation defined for path '/test/HTTPMethod'`,
+                `Request operations found for path '/test/HTTPMethod' in API spec: ${green('GET, POST')}`,
+              ),
             ),
           );
         });
@@ -614,10 +625,12 @@ openApiSpecs.forEach((spec) => {
           expect(assertion).toThrow(
             new Error(
               // prettier-ignore
-              c`${expectReceivedToSatisfyApiSpec}
-            \n\nexpected ${red('received')} to satisfy a '204' response defined for endpoint 'HEAD /test/pathParams/{exampleParam}' in your API spec
-            \n${red('received')} had request method ${red('HEAD')}, but your API spec has no ${red('HEAD')} operation defined for path '/test/pathParams/{exampleParam}'
-            \n\nRequest operations found for path '/test/pathParams/{exampleParam}' in API spec: ${green('GET')}`,
+              joinWithNewLines(
+                expectReceivedToSatisfyApiSpec,
+                `expected ${red('received')} to satisfy a '204' response defined for endpoint 'HEAD /test/pathParams/{exampleParam}' in your API spec`,
+                `${red('received')} had request method ${red('HEAD')}, but your API spec has no ${red('HEAD')} operation defined for path '/test/pathParams/{exampleParam}'`,
+                `Request operations found for path '/test/pathParams/{exampleParam}' in API spec: ${green('GET')}`,
+              ),
             ),
           );
         });

--- a/packages/jest-openapi/__test__/matchers/toSatisfySchemaInApiSpec/toSatisfySchemaInApiSpec.test.js
+++ b/packages/jest-openapi/__test__/matchers/toSatisfySchemaInApiSpec/toSatisfySchemaInApiSpec.test.js
@@ -1,8 +1,10 @@
 const path = require('path');
-const util = require('util');
-const { c } = require('compress-tag');
 const jestMatcherUtils = require('jest-matcher-utils');
 
+const {
+  joinWithNewLines,
+  str,
+} = require('../../../../../commonTestResources/utils');
 const jestOpenAPI = require('../../..');
 
 const expectReceivedToSatisfySchemaInApiSpec = jestMatcherUtils.matcherHint(
@@ -30,7 +32,6 @@ const expectReceivedNotToSatisfySchemaInApiSpec = jestMatcherUtils.matcherHint(
 const red = jestMatcherUtils.RECEIVED_COLOR;
 const green = jestMatcherUtils.EXPECTED_COLOR;
 
-const str = (obj) => util.inspect(obj, { showHidden: false, depth: null });
 const openApiSpecsDir = path.resolve(
   '../../commonTestResources/exampleOpenApiFiles/valid/satisfySchemaInApiSpec',
 );
@@ -71,10 +72,12 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               new Error(
                 // prettier-ignore
-                c`${expectReceivedNotToSatisfySchemaInApiSpec}
-                \n\nexpected ${red('received')} not to satisfy the '${schemaName}' schema defined in your API spec
-                \n${red('received')} was: ${red('\'string\'')}
-                \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+                joinWithNewLines(
+                  expectReceivedNotToSatisfySchemaInApiSpec,
+                  `expected ${red('received')} not to satisfy the '${schemaName}' schema defined in your API spec`,
+                  `${red('received')} was: ${red('\'string\'')}`,
+                  `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+                ),
               ),
             );
           });
@@ -89,11 +92,13 @@ openApiSpecs.forEach((spec) => {
             expect(assertion).toThrow(
               new Error(
                 // prettier-ignore
-                c`${expectReceivedToSatisfySchemaInApiSpec}
-                \n\nexpected ${red('received')} to satisfy the '${schemaName}' schema defined in your API spec
-                \n${red('received')} did not satisfy it because: object should be string
-                \n\n${red('received')} was: ${red(123)}
-                \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+                joinWithNewLines(
+                  expectReceivedToSatisfySchemaInApiSpec,
+                  `expected ${red('received')} to satisfy the '${schemaName}' schema defined in your API spec`,
+                  `${red('received')} did not satisfy it because: object should be string`,
+                  `${red('received')} was: ${red(123)}`,
+                  `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+                ),
               ),
             );
           });
@@ -120,9 +125,10 @@ openApiSpecs.forEach((spec) => {
               expect(validObj).not.toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`expected ${red('received')} not to satisfy the '${schemaName}' schema defined in your API spec
-              \n${red('received')} was: ${red(123)}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} was: ${red(123)}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
         });
@@ -135,10 +141,11 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`expected ${red('received')} to satisfy the '${schemaName}' schema defined in your API spec
-              \n${red('received')} did not satisfy it because: object should be integer
-              \n\n${red('received')} was: ${red('\'should be integer\'')}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} did not satisfy it because: object should be integer`,
+                `${red('received')} was: ${red('\'should be integer\'')}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
 
@@ -168,8 +175,10 @@ openApiSpecs.forEach((spec) => {
               expect(validObj).not.toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`${red('received')} was: ${red(str(validObj))}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} was: ${red(str(validObj))}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
         });
@@ -182,9 +191,11 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`${red('received')} did not satisfy it because: property1 should be string
-              \n\n${red('received')} was: ${red(str(invalidObj))}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} did not satisfy it because: property1 should be string`,
+                `${red('received')} was: ${red(str(invalidObj))}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
 
@@ -217,8 +228,10 @@ openApiSpecs.forEach((spec) => {
               expect(validObj).not.toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`${red('received')} was: ${red(str(validObj))}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} was: ${red(str(validObj))}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
         });
@@ -231,9 +244,11 @@ openApiSpecs.forEach((spec) => {
               expect(invalidObj).toSatisfySchemaInApiSpec(schemaName);
             expect(assertion).toThrow(
               // prettier-ignore
-              c`${red('received')} did not satisfy it because: property1 should be string
-              \n\n${red('received')} was: ${red(str(invalidObj))}
-              \n\nThe '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              joinWithNewLines(
+                `${red('received')} did not satisfy it because: property1 should be string`,
+                `${red('received')} was: ${red(str(invalidObj))}`,
+                `The '${schemaName}' schema in API spec: ${green(str(expectedSchema))}`,
+              ),
             );
           });
 

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -56,7 +56,6 @@
     "supertest": "^5.0.0"
   },
   "dependencies": {
-    "compress-tag": "^2.0.0",
     "jest-matcher-utils": "^26.5.2",
     "openapi-validator": "^0.9.0"
   }

--- a/packages/jest-openapi/src/matchers/toSatisfySchemaInApiSpec.js
+++ b/packages/jest-openapi/src/matchers/toSatisfySchemaInApiSpec.js
@@ -1,4 +1,3 @@
-const { c } = require('compress-tag');
 const {
   RECEIVED_COLOR,
   EXPECTED_COLOR,
@@ -8,7 +7,7 @@ const {
   printWithType,
 } = require('jest-matcher-utils');
 
-const { stringify } = require('../utils');
+const { stringify, joinWithNewLines } = require('../utils');
 
 module.exports = function (received, schemaName, openApiSpec) {
   const matcherHintOptions = {
@@ -70,11 +69,13 @@ function getExpectReceivedToSatisfySchemaInApiSpecMsg(
   hint,
 ) {
   // prettier-ignore
-  return c`${hint}
-    \n\nexpected ${RECEIVED_COLOR('received')} to satisfy the '${schemaName}' schema defined in your API spec
-    \n${RECEIVED_COLOR('received')} did not satisfy it because: ${validationError}
-    \n\n${RECEIVED_COLOR('received')} was: ${RECEIVED_COLOR(stringify(received))}
-    \n\nThe '${schemaName}' schema in API spec: ${EXPECTED_COLOR(stringify(schema))}`;
+  return joinWithNewLines(
+    hint,
+    `expected ${RECEIVED_COLOR('received')} to satisfy the '${schemaName}' schema defined in your API spec`,
+    `${RECEIVED_COLOR('received')} did not satisfy it because: ${validationError}`,
+    `${RECEIVED_COLOR('received')} was: ${RECEIVED_COLOR(stringify(received))}`,
+    `The '${schemaName}' schema in API spec: ${EXPECTED_COLOR(stringify(schema))}`,
+  );
 }
 
 function getExpectReceivedNotToSatisfySchemaInApiSpecMsg(
@@ -84,8 +85,10 @@ function getExpectReceivedNotToSatisfySchemaInApiSpecMsg(
   hint,
 ) {
   // prettier-ignore
-  return c`${hint}
-    \n\nexpected ${RECEIVED_COLOR('received')} not to satisfy the '${schemaName}' schema defined in your API spec
-    \n${RECEIVED_COLOR('received')} was: ${RECEIVED_COLOR(stringify(received))}
-    \n\nThe '${schemaName}' schema in API spec: ${EXPECTED_COLOR(stringify(schema))}`;
+  return joinWithNewLines(
+    hint,
+    `expected ${RECEIVED_COLOR('received')} not to satisfy the '${schemaName}' schema defined in your API spec`,
+    `${RECEIVED_COLOR('received')} was: ${RECEIVED_COLOR(stringify(received))}`,
+    `The '${schemaName}' schema in API spec: ${EXPECTED_COLOR(stringify(schema))}`,
+  );
 }

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/OpenApi2Spec.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/OpenApi2Spec.js
@@ -2,10 +2,30 @@ const utils = require('../utils');
 const AbstractOpenApiSpec = require('./AbstractOpenApiSpec');
 const ValidationError = require('./errors/ValidationError');
 
+const basePathPropertyNotProvided = (spec) =>
+  !Object.prototype.hasOwnProperty.call(spec, 'basePath');
+
 class OpenApi2Spec extends AbstractOpenApiSpec {
+  constructor(spec) {
+    super(spec);
+    this.didUserDefineBasePath = !basePathPropertyNotProvided(spec);
+  }
+
+  /**
+   * "If the basePath property is not provided, the API is served directly under the host
+   * @see https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields
+   */
   findOpenApiPathMatchingPathname(pathname) {
+    const { basePath } = this.spec;
+    if (basePath && !pathname.startsWith(basePath)) {
+      throw new ValidationError('BASE_PATH_NOT_FOUND');
+    }
+    const pathnameWithoutBasePath = utils.getPathnameWithoutBasePath(
+      basePath,
+      pathname,
+    );
     const openApiPath = utils.findOpenApiPathMatchingPossiblePathnames(
-      [pathname],
+      [pathnameWithoutBasePath],
       this.paths(),
     );
     if (!openApiPath) {

--- a/packages/jest-openapi/src/openapi-validator/lib/classes/OpenApi3Spec.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/classes/OpenApi3Spec.js
@@ -10,9 +10,6 @@ const serversPropertyNotProvidedOrIsEmptyArray = (spec) =>
 
 const extractBasePath = (inputUrl) => url.parse(inputUrl).path;
 
-const getPathnameWithoutBasePath = (basePath, pathname) =>
-  basePath === '/' ? pathname : pathname.replace(basePath, '');
-
 class OpenApi3Spec extends AbstractOpenApiSpec {
   constructor(spec) {
     super(spec);
@@ -68,7 +65,7 @@ class OpenApi3Spec extends AbstractOpenApiSpec {
       throw new ValidationError('SERVER_NOT_FOUND');
     }
     const possiblePathnames = matchingServerBasePaths.map((basePath) =>
-      getPathnameWithoutBasePath(basePath, pathname),
+      utils.getPathnameWithoutBasePath(basePath, pathname),
     );
     const openApiPath = utils.findOpenApiPathMatchingPossiblePathnames(
       possiblePathnames,

--- a/packages/jest-openapi/src/openapi-validator/lib/utils.js
+++ b/packages/jest-openapi/src/openapi-validator/lib/utils.js
@@ -46,9 +46,13 @@ const findOpenApiPathMatchingPossiblePathnames = (
   return openApiPath;
 };
 
+const getPathnameWithoutBasePath = (basePath, pathname) =>
+  basePath === '/' ? pathname : pathname.replace(basePath, '');
+
 module.exports = {
   isEmptyObj,
   stringify,
   extractPathname,
   findOpenApiPathMatchingPossiblePathnames,
+  getPathnameWithoutBasePath,
 };

--- a/packages/jest-openapi/src/utils.js
+++ b/packages/jest-openapi/src/utils.js
@@ -1,8 +1,10 @@
-const util = require('util');
+const { inspect } = require('util');
 
-const stringify = (obj) =>
-  util.inspect(obj, { showHidden: false, depth: null });
+const stringify = (obj) => inspect(obj, { showHidden: false, depth: null });
+
+const joinWithNewLines = (...lines) => lines.join('\n\n');
 
 module.exports = {
   stringify,
+  joinWithNewLines,
 };


### PR DESCRIPTION
* feat: support OpenAPI 2 basePath (https://github.com/RuntimeTools/OpenAPIValidators/pull/172)
* test: remove invalid test cases (https://github.com/RuntimeTools/OpenAPIValidators/pull/185)
* refactor: general tidy (https://github.com/RuntimeTools/OpenAPIValidators/pull/185)
* chore: drop unused dependency (compress-tag)