### PR TITLE
chore: release 0.10.0

### DIFF
--- a/packages/chai-openapi-response-validator/package.json
+++ b/packages/chai-openapi-response-validator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chai-openapi-response-validator",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Simple Chai support for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/jest-openapi/package.json
+++ b/packages/jest-openapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-openapi",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Jest matchers for asserting that HTTP responses satisfy an OpenAPI spec",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
**chai-openapi-response-validator** and **jest-openapi**

feat:
* support OpenAPI 2 basePaths https://github.com/RuntimeTools/OpenAPIValidators/pull/172 @tgiardina & https://github.com/RuntimeTools/OpenAPIValidators/pull/186 @rwalle61 
* (minor) add extra newline in error message https://github.com/RuntimeTools/OpenAPIValidators/pull/185 https://github.com/RuntimeTools/OpenAPIValidators/pull/186 @rwalle61

test:
* we dropped a few invalid test cases, which should not affect any users https://github.com/RuntimeTools/OpenAPIValidators/pull/185 https://github.com/RuntimeTools/OpenAPIValidators/pull/186 @rwalle61